### PR TITLE
add delete_intf.py script

### DIFF
--- a/python_DHCP_script/README.md
+++ b/python_DHCP_script/README.md
@@ -9,7 +9,7 @@ you through this process.
 * Add Security Policies to firewall via Homeskillet add-ons skillet
 * Turn off zone protect profiles
 
-# Setting up Client side Linuxbox
+## Setting up Client side Linuxbox
 You want to map your Client address to match the NGFW interface address.
 You also need to set up your routing table to allow the Client to route to remote
 networks. This section will walk you through that process. You will be using Paho to
@@ -26,7 +26,7 @@ connect to the Broker and publish messages(Paho-MQTT)
     + ```sudo ip route add {remote network IP} via {current routing gateway IP} dev {Linux interface}```
 
 
-# Setting up Broker side Linuxbox
+## Setting up Broker side Linuxbox
 You need to install MQTT on the broker side in order to have the
 Client publish messages and subscribe to topics. You also need to
 alter the routing table of the Broker to be able to route to remote
@@ -38,7 +38,7 @@ networks.
     + ```sudo ip route add {remote network IP} via {current routing gateway IP} dev {Linux interface}```
 
 
-# Running the IoT traffic generator
+## Running the IoT traffic generator
 Requires Linux host such as Ubuntu to run
 
 Prior to running the script be sure to do ``` make ```  
@@ -48,3 +48,15 @@ The command to run the traffic generation script is
 
 `sudo python3 iot_traffic.py`
 
+
+## Delete IoT Client Logical Interfaces
+
+For testing or a demo the `delete_intf.py` script will remove all interfaces with
+the specified prefix string.
+
+```bash
+sudo python delete_intf.py -p iot
+```
+
+> :warning: removing interfaces should be done with caution. Ensure the prefix string
+> matches only the logical interfaces added, by default using iot.

--- a/python_DHCP_script/delete_intf.py
+++ b/python_DHCP_script/delete_intf.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python3
+# Copyright (c) 2018, Palo Alto Networks
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+# Author: Bora MutluoGlu <bmutluoglu@paloaltonetworks.com>
+# Author: Scott Shoaf <sshoaf@paloaltonetworks.com>
+
+'''
+Palo Alto Networks IoT POC Interface Clean Up
+
+deletes the iotXX interfaces from the local host
+
+This software is provided without support, warranty, or guarantee.
+Use at your own risk.
+'''
+
+from subprocess import PIPE, Popen
+
+import click
+import netifaces
+
+
+def delete_logical_intf(intf_list, prefix_str):
+    """
+    for interfaces match the prefix string, delete the interface
+    :param intf_list: list of host interfaces
+    :param prefix_str: prefix string of interest
+    :return:
+    """
+
+    for interface in intf_list:
+        deletables = []
+        # interface the interfaces looking for one matching the prefix string
+        # then delete that interface
+        if prefix_str in interface:
+            print(interface)
+
+            print(f'deleting interface {interface}')
+
+            # delete interface
+            add_if = Popen(f'sudo ip link delete {interface}', shell=True, stdout=PIPE, stderr=PIPE)
+            stdout, stderr = add_if.communicate()
+
+            deletables.append(interface)
+
+    # courtesy message that no interfaces were found matching the prefix_str
+    if not deletables:
+        print(f'\nno interfaces starting with {prefix_str} were found\n')
+
+
+@click.command()
+@click.option("-p", "--prefix_str", help="prefix string for interfaces to be removed", type=str, default="iot")
+def cli(prefix_str):
+    """
+    delete interfaces
+    """
+
+    print('_' * 60)
+    print(f'\ndelete host interfaces starting with {prefix_str}')
+    print('_' * 60)
+
+    # get all interfaces starting with the prefix string
+    # print (netifaces.interfaces())
+    interfaces = netifaces.interfaces()
+
+    # delete interfaces
+    delete_logical_intf(interfaces, prefix_str)
+
+
+if __name__ == '__main__':
+    cli()

--- a/python_DHCP_script/requirements.txt
+++ b/python_DHCP_script/requirements.txt
@@ -2,3 +2,4 @@ click==7.1.2
 paho-mqtt==1.5.0
 pkg-resources==0.0.0
 scapy==2.4.3
+netifaces==0.10.9


### PR DESCRIPTION
## Description

addition of python script to delete Linux VM IoT client logical interfaces

## Motivation and Context

for demos and testing, add the ability to remove the configured logical interfaces and return the
linux host to an initial state

## How Has This Been Tested?

add/remove of interfaces in lab sandbox setup

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

New feature to assist with demo/testing

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
